### PR TITLE
Remove call-time pass-by-reference to fix fatal error in PHP 5.4

### DIFF
--- a/Controller/Component/DataTableComponent.php
+++ b/Controller/Component/DataTableComponent.php
@@ -273,7 +273,7 @@ class DataTableComponent extends Component {
 						$columnSearchTerm = $this->_params[$searchKey];
 					}
 					if (is_string($searchable) && is_callable(array($this->_Model, $searchable))) {
-						$this->_Model->$searchable($column, $searchTerm, $columnSearchTerm, &$conditions);
+						$this->_Model->$searchable($column, $searchTerm, $columnSearchTerm, $conditions);
 					} else {
 						if ($searchTerm) {
 							$conditions[] = array("$column LIKE" => '%' . $this->_params['sSearch'] . '%');


### PR DESCRIPTION
Reference signs on function calls has been deprecated in 5.4. This PR fixes this error:

```
2012-07-20 04:13:02 Error: Fatal Error (64): Call-time pass-by-reference has been removed in [/var/www/cake2plugins/DataTable/Controller/Component/DataTableComponent.php, line 276]
2012-07-20 04:13:02 Error: [FatalErrorException] Call-time pass-by-reference has been removed
#0 /var/www/cake/lib/Cake/Error/ErrorHandler.php(162): ErrorHandler::handleFatalError(64, 'Call-time pass-...', '/var/www/cake2p...', 276)
#1 [internal function]: ErrorHandler::handleError(64, 'Call-time pass-...', '/var/www/cake2p...', 276, Array)
#2 /var/www/cake/lib/Cake/Core/App.php(926): call_user_func('ErrorHandler::h...', 64, 'Call-time pass-...', '/var/www/cake2p...', 276, Array)
#3 /var/www/cake/lib/Cake/Core/App.php(899): App::_checkFatalError()
#4 [internal function]: App::shutdown()
#5 {main}
```
