### PR TITLE
Fixing issue with useField = false

### DIFF
--- a/Controller/Component/DataTableComponent.php
+++ b/Controller/Component/DataTableComponent.php
@@ -67,10 +67,10 @@ class DataTableComponent extends Component {
 				foreach ($config->columns as $column => $options) {
 					if (!$options['useField']) {
 						$row[] = null;
-						break;
+					} else {
+						$value = Hash::extract($result, $column);
+						$row[] = $value ? $value[0] : null;
 					}
-					$value = Hash::extract($result, $column);
-					$row[] = $value ? $value[0] : null;
 				}
 				$aaData[] = $row;
 			}


### PR DESCRIPTION
If the "useField = false" field is not the last one then it breaks the foreach and the row is not added to aaData. In docs example Actions => null is the last one so it works. I am using it with Actions as first field so empty aaData is returned. 